### PR TITLE
Detect Obsidian image format in markdown files

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -20,11 +20,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       
-    - name: Install Pester
+    - name: Install PowerShell Module Dependencies
       shell: pwsh
       run: |
         Set-PSRepository PSGallery -InstallationPolicy Trusted
         Install-Module -Name Pester -Force -SkipPublisherCheck
+        Install-Module -Name PowerShell-Yaml -Force -SkipPublisherCheck
         
     - name: Run Pester Tests
       shell: pwsh

--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -1,0 +1,84 @@
+name: Pester Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - '.github/workflows/pester-tests.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - '.github/workflows/pester-tests.yml'
+
+jobs:
+  test:
+    runs-on: windows-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Install Pester
+      shell: pwsh
+      run: |
+        Set-PSRepository PSGallery -InstallationPolicy Trusted
+        Install-Module -Name Pester -Force -SkipPublisherCheck
+        
+    - name: Run Pester Tests
+      shell: pwsh
+      run: |
+        # Import the module
+        Import-Module ./src/PSBlogger.psd1 -Force
+        
+        # Configure Pester
+        $PesterConfig = @{
+          Run = @{
+            Path = './src/tests'
+          }
+          Output = @{
+            Verbosity = 'Detailed'
+          }
+          TestResult = @{
+            Enabled = $true
+            OutputPath = 'TestResults.xml'
+            OutputFormat = 'NUnitXml'
+          }
+          CodeCoverage = @{
+            Enabled = $true
+            Path = './src/*.ps*1'
+            OutputPath = 'coverage.xml'
+            OutputFormat = 'JaCoCo'
+          }
+        }
+        
+        # Run tests
+        $Results = Invoke-Pester -Configuration $PesterConfig
+        
+        # Exit with error code if tests failed
+        if ($Results.FailedCount -gt 0) {
+          Write-Error "Tests failed: $($Results.FailedCount) failed out of $($Results.TotalCount) total tests"
+          exit 1
+        }
+        
+        Write-Host "All tests passed: $($Results.PassedCount) out of $($Results.TotalCount) tests"
+        
+    # - name: Publish Test Results
+    #   uses: dorny/test-reporter@v1
+    #   if: always()
+    #   with:
+    #     name: Pester Tests
+    #     path: TestResults.xml
+    #     reporter: java-junit
+    #     fail-on-error: true
+        
+    # - name: Upload Test Results
+    #   uses: actions/upload-artifact@v4
+    #   if: always()
+    #   with:
+    #     name: test-results
+    #     path: |
+    #       TestResults.xml
+    #       coverage.xml
+    #     retention-days: 7

--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -30,32 +30,41 @@ jobs:
     - name: Run Pester Tests
       shell: pwsh
       run: |
-        # Import the module
-        Import-Module ./src/PSBlogger.psd1 -Force
+        # Debug: Show current directory and files
+        Write-Host "Current directory: $(Get-Location)"
+        Write-Host "Directory structure:"
+        Get-ChildItem -Path . -Recurse | Select-Object FullName, PSIsContainer
+        
+        # Change to src directory to match test expectations
+        Set-Location "./src"
+        Write-Host "Changed to src directory: $(Get-Location)"
         
         # Configure Pester
         $PesterConfig = @{
           Run = @{
-            Path = './src/tests'
+            Path = './tests'
           }
           Output = @{
             Verbosity = 'Detailed'
           }
           TestResult = @{
             Enabled = $true
-            OutputPath = 'TestResults.xml'
+            OutputPath = '../TestResults.xml'
             OutputFormat = 'NUnitXml'
           }
           CodeCoverage = @{
             Enabled = $true
-            Path = './src/*.ps*1'
-            OutputPath = 'coverage.xml'
+            Path = './*.ps*1'
+            OutputPath = '../coverage.xml'
             OutputFormat = 'JaCoCo'
           }
         }
         
         # Run tests
         $Results = Invoke-Pester -Configuration $PesterConfig
+        
+        # Change back to root directory
+        Set-Location ".."
         
         # Exit with error code if tests failed
         if ($Results.FailedCount -gt 0) {

--- a/README.md
+++ b/README.md
@@ -68,17 +68,28 @@ A PowerShell library for publishing markdown files authored in markdown to Blogg
 
 ## Image Support
 
-PSBlogger supports Google Drive for hosting your images.
+PSBlogger supports Google Drive for hosting your images and handles both standard markdown and Obsidian image formats.
+
+### Supported Image Formats
+
+PSBlogger can detect and process images in both formats:
+
+- **Standard Markdown**: `![alt text](image.png "optional title")`
+- **Obsidian Format**: `![[image.png|alt text]]`
+
+When publishing, all images are converted to standard markdown format with Google Drive URLs, ensuring compatibility across platforms.
+
+### Google Drive Integration
 
 - Add-GoogleDriveFile: Uploads a file to your Google Drive
 - Add-GoogleDriveFolder: Creates a folder in your Google Drive
 - Get-GoogleDriveItems: Query the contents of your Google Drive
 - Set-GoogleDriveFilePermission: Modifes the permission of a file.
 
-Markdown methods for managing images.
+### Markdown Image Management
 
-- Find-MarkdownImages: scans the markdown file to locate images in the content.
-- Update-MarkdownImages: updates the content in the markdown file with updated urls
+- Find-MarkdownImages: scans the markdown file to locate images in both standard and Obsidian formats
+- Update-MarkdownImages: updates the content in the markdown file with updated urls, converting all formats to standard markdown
 
 ## Future
 

--- a/src/public/Find-MarkdownImages.ps1
+++ b/src/public/Find-MarkdownImages.ps1
@@ -3,7 +3,9 @@
     Finds all image references in a markdown file.
 
 .DESCRIPTION
-    Parses a markdown file and extracts all image references (both inline and reference-style).
+    Parses a markdown file and extracts all image references including:
+    - Standard markdown format: ![alt text](image_path "optional title")
+    - Obsidian format: ![[image_path|alt text]]
     Returns information about each image including the original markdown syntax, image path, alt text, and title.
 
 .PARAMETER File
@@ -23,17 +25,59 @@ function Find-MarkdownImages {
     $content = Get-Content -Path $File -Raw
     $images = @()
     $fileDirectory = Split-Path -Path $File -Parent
+    
+    # If the file is in the current directory, use the current directory
+    if ([string]::IsNullOrEmpty($fileDirectory)) {
+        $fileDirectory = "."
+    }
 
-    # Regex pattern for inline images: ![alt text](image_path "optional title")
-    $inlinePattern = '!\[([^\]]*)\]\(([^)]+?)(?:\s+"([^"]*)")?\)'
+    # Regex pattern for standard markdown images: ![alt text](image_path "optional title")
+    $standardPattern = '!\[([^\]]*)\]\(([^)]+?)(?:\s+"([^"]*)")?\)'
     
-    # Find all inline image matches
-    $inlineMatches = [regex]::Matches($content, $inlinePattern)
+    # Regex pattern for Obsidian images: ![[image_path|alt text]]
+    $obsidianPattern = '!\[\[([^|\]]+?)(?:\|([^\]]*))?\]\]'
     
-    foreach ($match in $inlineMatches) {
-        $altText = $match.Groups[1].Value
-        $imagePath = $match.Groups[2].Value.Trim()
-        $title = if ($match.Groups[3].Success) { $match.Groups[3].Value } else { "" }
+    # Collect all matches with their positions
+    $allMatches = @()
+    
+    # Find all standard markdown image matches
+    $standardMatches = [regex]::Matches($content, $standardPattern)
+    foreach ($match in $standardMatches) {
+        $allMatches += @{
+            Match = $match
+            Position = $match.Index
+            Format = "Standard"
+        }
+    }
+    
+    # Find all Obsidian image matches
+    $obsidianMatches = [regex]::Matches($content, $obsidianPattern)
+    foreach ($match in $obsidianMatches) {
+        $allMatches += @{
+            Match = $match
+            Position = $match.Index
+            Format = "Obsidian"
+        }
+    }
+    
+    # Sort matches by position in document
+    $allMatches = $allMatches | Sort-Object Position
+    
+    # Process each match in document order
+    foreach ($matchInfo in $allMatches) {
+        $match = $matchInfo.Match
+        $format = $matchInfo.Format
+        
+        if ($format -eq "Standard") {
+            $altText = $match.Groups[1].Value
+            $imagePath = $match.Groups[2].Value.Trim()
+            $title = if ($match.Groups[3].Success) { $match.Groups[3].Value } else { "" }
+        } else {
+            # Obsidian format
+            $imagePath = $match.Groups[1].Value.Trim()
+            $altText = if ($match.Groups[2].Success) { $match.Groups[2].Value } else { "" }
+            $title = ""  # Obsidian format doesn't support titles
+        }
         
         # Skip URLs (images already hosted online)
         if ($imagePath -match '^https?://') {

--- a/src/public/Update-MarkdownImages.ps1
+++ b/src/public/Update-MarkdownImages.ps1
@@ -3,8 +3,8 @@
 Updates markdown content by replacing local image references with Google Drive URLs.
 
 .DESCRIPTION
-Takes a markdown file and replaces local image references with Google Drive public URLs,
-while preserving alt text and titles.
+Takes a markdown file and replaces local image references with Google Drive public URLs, 
+converting all images to standard markdown format while preserving alt text and titles.
 
 .PARAMETER File
 The path to the markdown file to update.
@@ -15,9 +15,10 @@ Each object should have OriginalMarkdown and NewUrl properties.
 
 .EXAMPLE
 $mappings = @(
-    @{ OriginalMarkdown = "![alt](local.jpg)"; NewUrl = "https://drive.google.com/uc?export=view&id=123" }
+    @{ OriginalMarkdown = "![alt](local.jpg)"; NewUrl = "https://drive.google.com/uc?export=view&id=123"; AltText = "alt"; Title = "" }
+    @{ OriginalMarkdown = "![[image.png|description]]"; NewUrl = "https://drive.google.com/uc?export=view&id=456"; AltText = "description"; Title = "" }
 )
-Update-MarkdownImageUrls -File "post.md" -ImageMappings $mappings
+Update-MarkdownImages -File "post.md" -ImageMappings $mappings
 #>
 function Update-MarkdownImages {
     [CmdletBinding()]

--- a/src/tests/Set-BloggerConfig.Tests.ps1
+++ b/src/tests/Set-BloggerConfig.Tests.ps1
@@ -2,24 +2,28 @@
 Describe "Set-BloggerConfig" {
   BeforeEach {
     Import-Module $PSScriptRoot\..\PSBlogger.psm1 -Force
+    
+    # Ensure the test has a clean BloggerSession variable
     InModuleScope "PSBlogger" {
+      # Remove the existing variable if it exists
+      if (Get-Variable -Name BloggerSession -Scope Script -ErrorAction SilentlyContinue) {
+        Remove-Variable -Name BloggerSession -Scope Script -Force
+      }
+      
+      # Create a new test-specific BloggerSession
       $BloggerSession = [pscustomobject]@{
         BlogId = $null
         UserPreferences = "TestDrive:\UserPreferences.json"
       }
+      
+      # Set it as a script-scoped variable (same as the module does)
+      New-Variable -Name BloggerSession -Value $BloggerSession -Scope Script -Force
     }
   }
 
   It "Should persist new value to <UserPreference> to BloggerSession.UserPreferences" -TestCases @(
     @{ UserPreference="BlogId"; UserPreferenceValue="12345" }
   ) {
-    # arrange
-    InModuleScope "PSBlogger" {
-      $BloggerSession = [pscustomobject]@{
-        BlogId = $null
-        UserPreferences = "TestDrive:\UserPreferences.json"
-      }
-    }
 
     # act
     Set-BloggerConfig -Name $UserPreference -Value $UserPreferenceValue -ErrorAction Stop

--- a/src/tests/Set-BloggerConfig.Tests.ps1
+++ b/src/tests/Set-BloggerConfig.Tests.ps1
@@ -7,12 +7,20 @@ Describe "Set-BloggerConfig" {
         BlogId = $null
         UserPreferences = "TestDrive:\UserPreferences.json"
       }
-    }    
+    }
   }
 
   It "Should persist new value to <UserPreference> to BloggerSession.UserPreferences" -TestCases @(
     @{ UserPreference="BlogId"; UserPreferenceValue="12345" }
   ) {
+    # arrange
+    InModuleScope "PSBlogger" {
+      $BloggerSession = [pscustomobject]@{
+        BlogId = $null
+        UserPreferences = "TestDrive:\UserPreferences.json"
+      }
+    }
+
     # act
     Set-BloggerConfig -Name $UserPreference -Value $UserPreferenceValue -ErrorAction Stop
 


### PR DESCRIPTION
Updates `Find-MarkdownImages` to use markdown image format `![[folder.png|alt]]`

Resolves #5 