### PR TITLE
Get-BloggerPosts now includes -All parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Initialize-Blogger -ClientId <id> -ClientSecret <secret>
 ### Fetch the available blogs and set the first blog as the default
 $blogs = Get-BloggerBlogs
 $blogId = $blogs[0].id
-Set-BloggerConfig -BlogId $blogId
+Set-BloggerConfig -Name BlogId $blogId
 
 ### Fetch posts
 $posts = Get-BloggerPosts -All

--- a/README.md
+++ b/README.md
@@ -120,6 +120,30 @@ When publishing, all images are converted to standard markdown format with Googl
 - Find-MarkdownImages: scans the markdown file to locate images in both standard and Obsidian formats
 - Update-MarkdownImages: updates the content in the markdown file with updated urls, converting all formats to standard markdown
 
-## Future
+## Examples
 
-- Download existing posts to your machine in markdown
+## Download existing posts to your machine in markdown
+
+```powershell
+### Initialize the auth settings for your google account
+Initialize-Blogger -ClientId <id> -ClientSecret <secret>
+
+### Fetch the available blogs and set the first blog as the default
+$blogs = Get-BloggerBlogs
+$blogId = $blogs[0].id
+Set-BloggerConfig -BlogId $blogId
+
+### Fetch posts
+$posts = Get-BloggerPosts -All
+
+### Download Posts
+$total = $posts.count
+$count = 0
+foreach($post in $posts) {
+   $complete = $count++/$total * 100
+   Write-Progress -Activity "Downloading..." -PercentComplete $complete -Status "$complete% ($count of $total)"
+   $post = Get-BloggerPost -PostId $post.id -Format Markdown -FolderDateFormat "yyyy\\MM" -OutDirectory ".\Posts"
+   Write-Host "Downloaded: $($post.title) - $($post.published)"
+}
+Write-Progress -Activity "Downloading..." -Complete
+```

--- a/src/public/Get-BloggerPost.ps1
+++ b/src/public/Get-BloggerPost.ps1
@@ -71,9 +71,10 @@ Function Get-BloggerPost {
 
     # Construct a subfolder based on the published date
     if ($FolderDateFormat -and $result.published) {
-      $date = [datetime]::Parse($result.published)
-      $formattedDate = $date.ToString($FolderDateFormat)
+      $formattedDate = $result.published.ToString($FolderDateFormat)
+      Write-Verbose "Using published date '$formattedDate' for folder structure."
       $OutDirectory = Join-Path -Path $OutDirectory -ChildPath $formattedDate
+      Write-Verbose "Output directory set to: $OutDirectory"
     }
 
     # Ensure the output directory exists

--- a/src/public/Get-BloggerPosts.ps1
+++ b/src/public/Get-BloggerPosts.ps1
@@ -8,32 +8,45 @@
 .PARAMETER Status
   The status of the posts to retrieve. Valid values are "draft", "live", and "scheduled"
 #>
-Function Get-BloggerPosts
-{
-    [CmdletBinding()]
-    param(
-        [string]$BlogId,
+Function Get-BloggerPosts {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $false)]
+    [string]$BlogId,
 
-        [ValidateSet("draft","live","scheduled")]
-        [string]$Status = "live"
-    )
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("draft", "live", "scheduled")]
+    [string]$Status = "live",
 
-    if (!$PSBoundParameters.ContainsKey("BlogId"))
-    {
-      $BlogId = $BloggerSession.BlogId
-      if (0 -eq $BlogId) {
-        throw "BlogId not specified."
+    [Parameter(Mandatory = $false)]
+    [switch]$All
+  )
+
+  if (!$PSBoundParameters.ContainsKey("BlogId")) {
+    $BlogId = $BloggerSession.BlogId
+    if (0 -eq $BlogId) {
+      throw "BlogId not specified."
+    }
+  }
+
+  try {
+    $done = $false
+    $pageToken = $null
+    while (!$done) {
+      $uri = "https://www.googleapis.com/blogger/v3/blogs/$BlogId/posts?status=$status"
+      if ($pageToken) {
+        $uri += "&pageToken=$pageToken"
       }
-    }
+      $result = Invoke-GApi -uri $uri
+    
+      $result.items
 
-    try {
-        $uri = "https://www.googleapis.com/blogger/v3/blogs/$BlogId/posts?status=$status"
-    
-        $result = Invoke-GApi -uri $uri
-    
-        $result.items            
+      # loop if pageToken is present and -All switch is set
+      $pageToken = $result.nextPageToken
+      $done = $All.IsPresent -and $All -and [string]::IsNullOrEmpty($pageToken)
     }
-    catch {
-        Write-Error $_.ToString() -ErrorAction Stop
-    }
+  }
+  catch {
+    Write-Error $_.ToString() -ErrorAction Stop
+  }
 }

--- a/src/tests/Get-BloggerPost.Tests.ps1
+++ b/src/tests/Get-BloggerPost.Tests.ps1
@@ -182,7 +182,7 @@ Describe "Get-BloggerPost" {
           return @{ 
             id = $postId
             title = "Test Post"
-            published = "2023-10-01T12:00:00Z"
+            published = "10/01/2023 12:00:00"
             content = "<h1>Hello World</h1><p>This is a post.</p>" 
           }
         }
@@ -225,7 +225,7 @@ Describe "Get-BloggerPost" {
           return @{ 
             id = $postId
             title = "Test Post"
-            published = "2023-10-01T12:00:00Z"
+            published = "10/01/2023 12:00:00"
             content = "<h1>Hello World</h1><p>This is a post.</p>" 
           }
         }

--- a/src/tests/Get-BloggerPost.Tests.ps1
+++ b/src/tests/Get-BloggerPost.Tests.ps1
@@ -225,7 +225,7 @@ Describe "Get-BloggerPost" {
           return @{ 
             id = $postId
             title = "Test Post"
-            published = "10/01/2023 12:00:00"
+            published = [datetime]"10/01/2023 12:00:00"
             content = "<h1>Hello World</h1><p>This is a post.</p>" 
           }
         }

--- a/src/tests/Get-BloggerPosts.Tests.ps1
+++ b/src/tests/Get-BloggerPosts.Tests.ps1
@@ -1,0 +1,46 @@
+Describe "Get-BloggerPosts" {
+
+  BeforeEach {
+    Import-Module $PSScriptRoot\..\PSBlogger.psm1 -Force
+  }
+
+  Context "Retrieve All Posts" {
+    BeforeEach {
+      InModuleScope PSBlogger {
+
+        $BloggerSession.BlogId = "123456789"
+
+        # Setup initial get-bloggerposts
+        Mock Invoke-GApi {
+          return @{
+            items = @(
+              @{ id = "1"; title = "Post 1"; published = "2023-10-01T00:00:00Z" },
+              @{ id = "2"; title = "Post 2"; published = "2023-10-02T00:00:00Z" }
+            )
+            nextPageToken = "1"
+          }
+        } -ParameterFilter { $uri -notlike "*pageToken*" }
+      
+
+        # setup second call
+        Mock Invoke-GApi {
+          @{
+            items = @(
+              @{ id = "3"; title = "Post 3"; published = "2023-10-03T00:00:00Z" }
+            )
+            nextPageToken = $null
+          }
+        } -ParameterFilter { $uri -like "*pageToken*" }
+      }
+    }
+
+    It "Should fetch all posts when -All switch is used" {
+
+      # act
+      $result = Get-BloggerPosts -All
+
+      # assert
+      $result.Count | Should -Be 3
+    }
+  }
+}

--- a/src/tests/Get-BloggerPosts.Tests.ps1
+++ b/src/tests/Get-BloggerPosts.Tests.ps1
@@ -42,5 +42,84 @@ Describe "Get-BloggerPosts" {
       # assert
       $result.Count | Should -Be 3
     }
+
+    It "Should only fetch initial set if -All switch is not used" {
+      # arrange
+      InModuleScope PSBlogger {
+        # Setup initial get-bloggerposts
+        Mock Invoke-GApi {
+          return @{
+            items = @(
+              @{ id = "1"; title = "Post 1"; published = "2023-10-01T00:00:00Z" },
+              @{ id = "2"; title = "Post 2"; published = "2023-10-02T00:00:00Z" }
+            )
+            nextPageToken = $null
+          }
+        } -ParameterFilter { $uri -notlike "*pageToken*" }
+      }
+
+      # act
+      $result = Get-BloggerPosts -All
+
+      # assert
+      $result.Count | Should -Be 2
+    }
+  }
+
+  Context "Retrieve Posts with Date Filter" {
+    BeforeEach {
+      InModuleScope PSBlogger {
+
+        $BloggerSession.BlogId = "123456789"
+      }
+    }
+
+    It "Should filter posts based on Since parameter" {
+      # arrange
+      InModuleScope PSBlogger {
+
+        # Mock the API call to return posts after a specific date
+        Mock Invoke-GApi {
+          return @{
+            items = @(
+              @{ id = "1"; title = "Post 1"; published = "2023-10-01T00:00:00Z" },
+              @{ id = "2"; title = "Post 2"; published = "2023-10-02T00:00:00Z" }
+            )
+            nextPageToken = $null
+          }
+        } -ParameterFilter { $uri -like "*since=2023-09-30*" }
+      }
+
+      # act
+      $result = Get-BloggerPosts -Since (Get-Date "2023-09-30")
+
+      # assert
+      $result.Count | Should -Be 2
+      $result[0].title | Should -Be "Post 1"
+      $result[1].title | Should -Be "Post 2"
+    }
+
+    It "Should not constrain by date if Since parameter is not provided" {
+      # arrange
+      InModuleScope PSBlogger {
+
+        # Mock the API call to return all posts
+        Mock Invoke-GApi {
+          return @{
+            items = @(
+              @{ id = "1"; title = "Post 1"; published = "2023-10-01T00:00:00Z" },
+              @{ id = "2"; title = "Post 2"; published = "2023-10-02T00:00:00Z" }
+            )
+            nextPageToken = $null
+          }
+        } -ParameterFilter { $uri -notlike "*since*" }
+      }
+
+      # act
+      $result = Get-BloggerPosts
+
+      # assert
+      $result.Count | Should -Be 2
+    }
   }
 }


### PR DESCRIPTION
Resolves #15 

New method `Get-BloggerPosts` has the following parameters:

- Since: `datetime`, optional. returns all posts older than the supplied date
- All: `switch`, optional. returns all paginated results