### PR TITLE
Include labels in markdown 

### DIFF
--- a/src/private/Get-BloggerSession.ps1
+++ b/src/private/Get-BloggerSession.ps1
@@ -11,6 +11,7 @@ Function Get-BloggerSession
       PandocTemplate = "$($env:USERPROFILE)\\.PSBlogger\\template.html"
       PandocAdditionalArgs = "--html-q-tags --ascii"
       BlogId = $null
+      ExcludeLabels = @()
     }
 
   if (Test-Path $session.UserPreferences)

--- a/src/public/Get-BloggerConfig.ps1
+++ b/src/public/Get-BloggerConfig.ps1
@@ -11,5 +11,6 @@ Function Get-BloggerConfig
     PandocHtmlFormat = $BloggerSession.PandocHtmlFormat
     PandocAdditionalArgs = $BloggerSession.PandocAdditionalArgs
     BlogId = $BloggerSession.BlogId
+    ExcludeLabels = $BloggerSession.ExcludeLabels
   }
 }

--- a/src/public/Get-BloggerPost.ps1
+++ b/src/public/Get-BloggerPost.ps1
@@ -115,6 +115,7 @@ Function Get-BloggerPost {
           $title = $result.title
           $frontMatter = [ordered]@{
             postId = $result.id
+            tags = $result.labels
           }
           $file = "$title.md"
           $filePath = Join-Path -Path $OutDirectory -ChildPath $file

--- a/src/public/Get-BloggerPost.ps1
+++ b/src/public/Get-BloggerPost.ps1
@@ -115,7 +115,11 @@ Function Get-BloggerPost {
           $title = $result.title
           $frontMatter = [ordered]@{
             postId = $result.id
-            tags = $result.labels
+          }
+          if ($result['labels']) {
+            $frontMatter['tags'] = $result.labels
+          } else {
+            $frontMatter['tags'] = @()
           }
           $file = "$title.md"
           $filePath = Join-Path -Path $OutDirectory -ChildPath $file

--- a/src/public/Publish-MarkdownBloggerPost.ps1
+++ b/src/public/Publish-MarkdownBloggerPost.ps1
@@ -58,6 +58,10 @@ Function Publish-MarkdownBloggerPost
     }
   }
 
+  if (!$PSBoundParameters.ContainsKey("ExcludeLabels")) {
+    $ExcludeLabels = $BloggerSession.ExcludeLabels
+  }
+
   # grab the front matter
   $postInfo = Get-MarkdownFrontMatter -File $File
 

--- a/src/public/Publish-MarkdownBloggerPost.ps1
+++ b/src/public/Publish-MarkdownBloggerPost.ps1
@@ -43,7 +43,11 @@ Function Publish-MarkdownBloggerPost
     [switch]$Draft,
 
     [Parameter(Mandatory=$false)]
+    [array]$ExcludeLabels = @(),
+
+    [Parameter(Mandatory=$false)]
     [switch]$Force
+
   )
 
   if (!$PSBoundParameters.ContainsKey("BlogId"))
@@ -79,7 +83,7 @@ Function Publish-MarkdownBloggerPost
   }
 
   if ($postInfo["tags"]) {
-    $postArgs.Labels = [array]$postInfo.tags
+    $postArgs.Labels = [array]$postInfo.tags | Where-Object { $_ -notin $ExcludeLabels }
   }
   
   $post = Publish-BloggerPost @postArgs

--- a/src/public/Set-BloggerConfig.ps1
+++ b/src/public/Set-BloggerConfig.ps1
@@ -3,12 +3,12 @@ Function Set-BloggerConfig
   [CmdletBinding()]
   Param(
     [Parameter(Mandatory=$true)]
-    [ValidateSet("BlogId","PandocAdditionalArgs","PandocHtmlFormat","PandocMarkdownFormat")]
+    [ValidateSet("BlogId","PandocAdditionalArgs","PandocHtmlFormat","PandocMarkdownFormat","ExcludeLabels")]
     [string]$Name,
 
     [Parameter(Mandatory=$true)]
     [AllowEmptyString()]
-    [string]$Value
+    $Value
   )
   $userPreferences = [pscustomobject]@{}
 

--- a/src/tests/Get-BloggerPost.Tests.ps1
+++ b/src/tests/Get-BloggerPost.Tests.ps1
@@ -184,6 +184,7 @@ Describe "Get-BloggerPost" {
             title = "Test Post"
             published = [datetime]"2023-10-01T17:30:00-04:00"
             content = "<h1>Hello World</h1><p>This is a post.</p>" 
+            labels = @("Azure DevOps", "Azure Pipelines")
           }
         }
       }
@@ -200,7 +201,7 @@ Describe "Get-BloggerPost" {
       }
     }
 
-    It "Should write post details to frontmatter" {
+    It "Should write postid to frontmatter" {
       
       # act
       Get-BloggerPost -PostId $postId -Format Markdown -OutDirectory "TestDrive:\"
@@ -208,6 +209,17 @@ Describe "Get-BloggerPost" {
       # assert
       $frontMatter = Get-MarkdownFrontMatter -File $outFile
       $frontMatter.postId | Should -Be "123"
+    }
+
+    It "Should write labels to frontmatter" {
+      # act
+      Get-BloggerPost -PostId $postId -Format Markdown -OutDirectory "TestDrive:\"
+
+      # assert
+      $frontMatter = Get-MarkdownFrontMatter -File $outFile
+      $frontMatter.tags.Count | Should -Be 2
+      $frontMatter.tags[0] | Should -Be "Azure DevOps"
+      $frontMatter.tags[1] | Should -Be "Azure Pipelines"
     }
   }
 

--- a/src/tests/Publish-MarkdownBloggerPost.Tests.ps1
+++ b/src/tests/Publish-MarkdownBloggerPost.Tests.ps1
@@ -165,6 +165,26 @@ postId: "123456"
     # assert
     Should -InvokeVerifiable 
   }
+
+  It "Should use excludelabels user preference when not specified" {
+    # arrange
+    InModuleScope PSBlogger {
+      $BloggerSession.ExcludeLabels = @("personal/blog-post")
+      Mock Publish-BloggerPost -Verifiable -ParameterFilter { 
+        $Labels -ne $null -and (-not (Compare-Object $Labels @("PowerShell","Pester")))} { return @{ id="123"} }
+    }
+
+    # add our tags to the file
+    $postInfo = Get-MarkdownFrontMatter -File $validFile
+    $postInfo.tags = @("PowerShell","Pester", "personal/blog-post")
+    Set-MarkdownFrontMatter -File $validFile -Replace $postInfo
+
+    # act
+    Publish-MarkdownBloggerPost -File $validFile -BlogId "123"
+
+    # assert
+    Should -InvokeVerifiable 
+  }
   
   It "Should update front matter with postid after publishing" {
     # arrange

--- a/src/tests/Publish-MarkdownBloggerPost.Tests.ps1
+++ b/src/tests/Publish-MarkdownBloggerPost.Tests.ps1
@@ -146,6 +146,25 @@ postId: "123456"
     Should -InvokeVerifiable 
   }
 
+  It "Should exclude certain tags from post labels when publishing " {
+    # arrange
+
+    # add our tags to the file
+    $postInfo = Get-MarkdownFrontMatter -File $validFile
+    $postInfo.tags = @("PowerShell","Pester", "personal/blog-post")
+    Set-MarkdownFrontMatter -File $validFile -Replace $postInfo
+
+    InModuleScope PSBlogger {
+      Mock Publish-BloggerPost -Verifiable -ParameterFilter { 
+        $Labels -ne $null -and (-not (Compare-Object $Labels @("PowerShell","Pester")))} { return @{ id="123"} }
+    }
+
+    # act
+    Publish-MarkdownBloggerPost -File $validFile -BlogId "123" -ExcludeLabels "personal/blog-post"
+
+    # assert
+    Should -InvokeVerifiable 
+  }
   
   It "Should update front matter with postid after publishing" {
     # arrange

--- a/src/tests/Set-BloggerConfig.Tests.ps1
+++ b/src/tests/Set-BloggerConfig.Tests.ps1
@@ -13,6 +13,7 @@ Describe "Set-BloggerConfig" {
       # Create a new test-specific BloggerSession
       $BloggerSession = [pscustomobject]@{
         BlogId = $null
+        ExcludeLabels = @()
         UserPreferences = "TestDrive:\UserPreferences.json"
       }
       
@@ -23,6 +24,7 @@ Describe "Set-BloggerConfig" {
 
   It "Should persist new value to <UserPreference> to BloggerSession.UserPreferences" -TestCases @(
     @{ UserPreference="BlogId"; UserPreferenceValue="12345" }
+    @{ UserPreference="ExcludeLabels"; UserPreferenceValue=@("personal/blog-post") }
   ) {
 
     # act
@@ -37,6 +39,7 @@ Describe "Set-BloggerConfig" {
 
   It "Should persist new value to <UserPreference> to empty BloggerSession.UserPreferences file" -TestCases @(
     @{ UserPreference="BlogId"; UserPreferenceValue="12345" }
+    @{ UserPreference="ExcludeLabels"; UserPreferenceValue=@("personal/blog-post") }
   ) {
     # arrange: empty file
     Set-Content TestDrive:\UserPreferences.json -Value "{}"


### PR DESCRIPTION
Addresses #19 

- blogger "labels" are added to markdown as "tags" to support Obsidian tagging.
- `Publish-MarkdownBloggerPost` now includes -ExcludeLabels which will filter out specific tags. For example, if you have a tag in your obsidian vault like, `#personal/blog-post` these can be excluded from the markdown when publishing to Blogger.
- `Set-BloggerConfig` now supports `ExcludeLabels` so you don't have to specify this every time you publish