### PR TITLE
Update workflow for release notes

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -3,8 +3,6 @@ name: Pester Tests
 on:
   pull_request:
     branches: [ main ]
-  push:
-    branches: [ main ]
 
 jobs:
   pester-tests:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -286,45 +286,18 @@ jobs:
           Write-Host "Created and pushed tag v${{ steps.version.outputs.version }}"
         }
     
-    - name: Get Commit Messages for Release Notes
-      if: steps.run-mode.outputs.is-dry-run == 'false'
-      id: release-notes
-      shell: pwsh
-      run: |
-        # Get the previous tag
-        $previousTag = git describe --tags --abbrev=0 "v${{ steps.version.outputs.version }}~1" 2>$null
-        if ($LASTEXITCODE -ne 0) {
-          # If no previous tag, get last 10 commits
-          $commits = git log --oneline --pretty=format:"- %s (%h)" -n 10
-        } else {
-          # Get commits since the previous tag
-          $commits = git log --oneline --pretty=format:"- %s (%h)" "$previousTag..v${{ steps.version.outputs.version }}"
-        }
-        
-        $releaseNotes = @"
-        ## Changes in version ${{ steps.version.outputs.version }}
-        
-        $($commits -join "`n")
-        
-        ## Installation
-        ``````powershell
-        Install-Module -Name PSBlogger -RequiredVersion ${{ steps.version.outputs.version }}
-        ``````
-        "@
-        
-        # Escape for GitHub Actions
-        $releaseNotes = $releaseNotes -replace "`r`n", "`n" -replace "`n", "%0A"
-        echo "release-notes=$releaseNotes" >> $env:GITHUB_OUTPUT
-    
     - name: Create GitHub Release
       if: steps.run-mode.outputs.is-dry-run == 'false'
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: v${{ steps.version.outputs.version }}
-        release_name: Release v${{ steps.version.outputs.version }}
-        body: ${{ steps.release-notes.outputs.release-notes }}
+        name: Release v${{ steps.version.outputs.version }}
+        generate_release_notes: true
+        body: |
+          ## Installation
+          ```powershell
+          Install-Module -Name PSBlogger -RequiredVersion ${{ steps.version.outputs.version }}
+          ```
         draft: false
         prerelease: false
     

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,5 @@
 name: PowerShell Gallery Publishing
 
-permissions:
-  contents: write
-
 on:
   # Automatic trigger: when module version changes on main branch
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -293,6 +293,7 @@ jobs:
         tag_name: v${{ steps.version.outputs.version }}
         name: Release v${{ steps.version.outputs.version }}
         generate_release_notes: true
+        append_body: true
         body: |
           ## Installation
           ```powershell

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: PowerShell Gallery Publishing
 
+permissions:
+  contents: write
+
 on:
   # Automatic trigger: when module version changes on main branch
   push:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A PowerShell library for publishing markdown files authored in markdown to Blogg
    choco install pandoc
    ```
 
-   (Future: still need to publish to PowerShell nuget library)
    ```
    Install-Module PSBlogger
    ```

--- a/src/PSBlogger.psd1
+++ b/src/PSBlogger.psd1
@@ -5,7 +5,7 @@
 RootModule = 'PSBlogger.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.3.1'
+ModuleVersion = '0.3.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/PSBlogger.psd1
+++ b/src/PSBlogger.psd1
@@ -5,7 +5,7 @@
 RootModule = 'PSBlogger.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.3.0'
+ModuleVersion = '0.3.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/PSBlogger.psd1
+++ b/src/PSBlogger.psd1
@@ -5,7 +5,7 @@
 RootModule = 'PSBlogger.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.3.2'
+ModuleVersion = '0.4.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
Resolves #37 

- Use [softprops/action-gh-release](https://github.com/softprops/action-gh-release?tab=readme-ov-file)
- Suppress ci workflow (redundant)
- updated readme as this is now in the powershell gallery
