### PR TITLE
Prompt and install Pandoc using Chocolatey

### DIFF
--- a/src/PSBlogger.psd1
+++ b/src/PSBlogger.psd1
@@ -5,7 +5,7 @@
 RootModule = 'PSBlogger.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.4.0'
+ModuleVersion = '0.5.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/private/ModuleInitHelpers.ps1
+++ b/src/private/ModuleInitHelpers.ps1
@@ -4,3 +4,57 @@ function Test-IsAdmin
   $principal = New-Object System.Security.Principal.WindowsPrincipal($currentIdentity)
   return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
 }
+
+function Test-PandocInstalled {
+  [CmdletBinding()]
+  [OutputType([bool])]
+  param()
+
+  try {
+    $null = Get-Command pandoc -ErrorAction Stop
+    Write-Verbose "Pandoc is installed and available in PATH"
+    return $true
+  }
+  catch {
+    Write-Verbose "Pandoc is not installed or not available in PATH"
+    return $false
+  }
+}
+
+function Test-ChocolateyInstalled {
+  [CmdletBinding()]
+  [OutputType([bool])]
+  param()
+  
+  try {
+    $null = Get-Command choco -ErrorAction Stop
+    Write-Verbose "Chocolatey is installed and available in PATH"
+    return $true
+  }
+  catch {
+    Write-Verbose "Chocolatey is not installed or not available in PATH"
+    return $false
+  }
+}
+
+function Install-PandocWithChocolatey {
+  [CmdletBinding()]
+  param()
+  
+  Write-Information "Installing Pandoc using Chocolatey..."
+  
+  try {
+    $process = Start-Process choco -ArgumentList "install", "pandoc", "-y" -NoNewWindow -Wait -PassThru
+    
+    if ($process.ExitCode -eq 0) {
+      Write-Information "Pandoc installation completed successfully."
+      Write-Information "You may need to restart your PowerShell session for Pandoc to be available in PATH."
+    }
+    else {
+      Write-Error "Pandoc installation failed with exit code: $($process.ExitCode)"
+    }
+  }
+  catch {
+    Write-Error "Failed to install Pandoc: $($_.Exception.Message)"
+  }
+}

--- a/src/public/Initialize-Blogger.ps1
+++ b/src/public/Initialize-Blogger.ps1
@@ -23,9 +23,13 @@ Initiate a login flow with Google
 
 .NOTES
   Note that this function requires administrator permissions to support the authentication flow.
+  
+  Pandoc is a dependency for this module. If it's not installed and the user has Chocolately installed,
+  the function will prompt to install pandoc using Chocolatey. To disable the prompt, change the
+  ConfirmPreference to 'None' or use the -Confirm:$false parameter. 
 #>
 Function Initialize-Blogger {
-  [CmdletBinding()]
+  [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
   Param(
     [Parameter(HelpMessage = "Google API ClientId")]
     [string]$ClientId = "<<CLIENT_ID>>",
@@ -45,6 +49,21 @@ Function Initialize-Blogger {
   }
 
   $ErrorActionPreference = 'Stop'
+
+  # Check if Pandoc is installed
+  if (-not (Test-PandocInstalled)) {
+    Write-Warning "Pandoc is not installed or not available in PATH."
+    
+    if (Test-ChocolateyInstalled) {
+      # Prompt user to install Pandoc using Chocolatey if $ConfirmPreference is set to 'Medium' or higher
+      if ($PSCmdlet.ShouldProcess("Pandoc", "Install using Chocolatey")) {
+        Install-PandocWithChocolatey
+      }
+      else {
+        Write-Warning "Pandoc installation skipped. Note that certain functions may fail."
+      }
+    }
+  }
 
   # Show warning to developers if they attempt to use the neutered credentials by mistake
   if ($env:PSBLOGGER_CLIENT_ID -and !$PSBoundParameters.ContainsKey("ClientId"))


### PR DESCRIPTION
Resolves #31 

When the user has chocolatey installed the system will prompt to install pandoc when you call Initialize-Blogger.

Notes:
- The prompt only appears if you have `$ConfirmPreference` set to High.
- You can suppress the prompt by using `-Confirm:$False`